### PR TITLE
[SD-67] Add support for Dense Layers

### DIFF
--- a/model_training/create_dataset.sh
+++ b/model_training/create_dataset.sh
@@ -47,7 +47,7 @@ python convert_measurements.py \
     --preprocessed-data-dir "$PREPROCESSED_DATA_DIR" \
     --result-dir "$TRAIN_DATA_DIR"
 
-COMMIT_MESSAGE="Add training data"
+COMMIT_MESSAGE="Modify training data to include conv_1x1 as dense layers"
 
 echo "Push training data to DagsHub"
 python data_version.py \

--- a/model_training/data_preparation/convert.py
+++ b/model_training/data_preparation/convert.py
@@ -52,11 +52,24 @@ def get_pooling_features(layer_info: TensorRTLayer) -> dict[str, int]:
 
 
 def get_dense_features(layer_info: TensorRTLayer) -> dict[str, int]:
-    """Get features for a dense layer."""
+    """Get features for a dense layer.
+
+    We also consider conv 1x1 as a dense layer.
+    """
     return {
         "batch_size": layer_info.inputs[0].dimensions[0],
-        "input_size": layer_info.inputs[0].dimensions[1],  # We skip batch size
-        "output_size": layer_info.outputs[0].dimensions[1],  # We skip batch size
+        "input_size": (
+            layer_info.inputs[0].dimensions[0]
+            * layer_info.inputs[0].dimensions[1]
+            * layer_info.inputs[0].dimensions[2]
+            * layer_info.inputs[0].dimensions[3]
+        ),
+        "output_size": (
+            layer_info.outputs[0].dimensions[0]
+            * layer_info.outputs[0].dimensions[1]
+            * layer_info.outputs[0].dimensions[2]
+            * layer_info.outputs[0].dimensions[3]
+        ),
     }
 
 

--- a/model_training/data_preparation/tensorrt_utils.py
+++ b/model_training/data_preparation/tensorrt_utils.py
@@ -48,11 +48,11 @@ class TensorRTLayer(BaseModel):
         Returns:
             str: Name of the layer
         """
-        if self.parameter_type == "Pooling":
+        if self.layer_type == "CaskPooling":
             return "pooling"
-        elif self.parameter_type == "Convolution":
+        elif self.layer_type == "CaskConvolution":
             return "convolutional"
-        elif self.layer_type == "gemm":
+        elif self.layer_type == "CaskGemmConvolution":
             return "dense"
         else:
             return self.layer_type


### PR DESCRIPTION
In this PR, we add support for dense layers. Dense layers are equivalent to `CaskGemmConvolution` in TensorRT engine info. These layers are either matrix multiplication or convolution of 1x1 kernel size.

From [Neural Power paper](https://arxiv.org/pdf/1710.05420), section 4.1.2 also mentions treating both the same

> Fully-connected layer: We employ a regression model with degree of two, and as features of the model we include the batch size, the input tensor size, and the output tensor size. 

> It is worth noting that in terms of software implementation, there are two common ways to implement the fully-connected layer, either based on default matrix multiplication, or based on a convolutional-like implementation (i.e., by keeping the kernel size exactly same as the input image patch size).

> Upon profiling, we notice that both cases have a tensor-reshaping stage when accepting intermediate results from a previous convolutional layer, so we treat them interchangeably under a single formulation


DagsHub training dataset is updated: https://dagshub.com/fuzzylabs/edge-vision-power-estimation to include dense layers for all models.