### PR TITLE
[SD-84] Track correct git commit URL and train data tag in MLFlow runs

### DIFF
--- a/model_training/README.md
+++ b/model_training/README.md
@@ -137,7 +137,14 @@ After the PR related to train dataset is merged, a tag for that specific version
 dvc pull training_data -r origin
 ```
 
-This will download training data from the FuzzyLabs [DagsHub repository](https://dagshub.com/fuzzylabs/edge-vision-power-estimation) to the `training_data` folder on your local filesystem.
+This will download the latest training data from the FuzzyLabs [DagsHub repository](https://dagshub.com/fuzzylabs/edge-vision-power-estimation) to the `training_data` folder on your local filesystem.
+
+Alternatively, you can also choose to download any of the older training data using git tags. For example, following command will pull training data corresponding to `train/v1` git tag.
+
+```bash
+git checkout train/v1 -- training_data.dvc
+dvc checkout training_data.dvc
+```
 
 > [!NOTE]
 > This step is recommended if you want to get started with training the models using data already present on DagsHub repository. </br>

--- a/model_training/run.py
+++ b/model_training/run.py
@@ -3,13 +3,12 @@
 from pathlib import Path
 from typing import Any
 
-from git import Repo
-from loguru import logger
-
 from config.convolutional_features import CONV_FEATURES, CONVOLUTION_PIPELINE
 from config.dense_features import DENSE_FEATURES, DENSE_PIPELINE
 from config.pooling_features import POOLING_FEATURES, POOLING_PIPELINE
 from data_preparation.io_utils import read_yaml_file
+from git import Repo
+from loguru import logger
 from trainer.trainer import Trainer
 
 
@@ -53,9 +52,9 @@ def get_train_data_version(root_git_dir: str = "..") -> str | None:
     except Exception as e:
         logger.warning(
             "No tag found for current 'model_training/training_data.dvc' file\n"
-            f"Command failed with following error : {e}"
+            f"Using commit as tag : {current_commit}"
         )
-        return None
+        return current_commit
 
 
 def train_pipeline(
@@ -114,9 +113,6 @@ def main(config: dict) -> None:
     """
     data_tag = get_train_data_version(root_git_dir="..")
     logger.info(f"Found training data tag: {data_tag}")
-    if data_tag is None:
-        logger.critical("No data tag found for the training data")
-        exit(1)
 
     mlflow_config = config["mlflow"]
     # Optionally enable mlflow tracking

--- a/model_training/run.py
+++ b/model_training/run.py
@@ -84,7 +84,9 @@ def train_pipeline(
 
     dataset = trainer.get_dataset(pattern=pattern)
     if dataset is None:
-        logger.warning("No dataset found for training")
+        logger.critical(
+            f"No dataset found for training model : {model_type} and layer: {layer_type}"
+        )
         return
 
     pipeline = trainer.get_model(

--- a/model_training/run.py
+++ b/model_training/run.py
@@ -113,6 +113,7 @@ def main(config: dict) -> None:
         config: Configuration dict.
     """
     data_tag = get_train_data_version(root_git_dir="..")
+    logger.info(f"Found training data tag: {data_tag}")
     if data_tag is None:
         logger.critical("No data tag found for the training data")
         exit(1)
@@ -130,7 +131,6 @@ def main(config: dict) -> None:
         )
 
         mlflow.set_experiment(mlflow_config["mlflow_experiment_name"])
-        logger.info(f"Found training data tag: {data_tag}")
 
         mlflow.sklearn.autolog()
 

--- a/model_training/run.py
+++ b/model_training/run.py
@@ -122,17 +122,12 @@ def main(config: dict) -> None:
     # Optionally enable mlflow tracking
     if mlflow_config["enable_tracking"]:
         import dagshub
-        import mlflow
 
         dagshub.init(
             repo_name=mlflow_config["dagshub_repo_name"],
             repo_owner=mlflow_config["dagshub_repo_owner"],
             mlflow=True,
         )
-
-        mlflow.set_experiment(mlflow_config["mlflow_experiment_name"])
-
-        mlflow.sklearn.autolog()
 
     # Train power and runtime for convolutional layer
     for model_type in ["power", "runtime"]:

--- a/model_training/run.py
+++ b/model_training/run.py
@@ -3,6 +3,9 @@
 from pathlib import Path
 from typing import Any
 
+from git import Repo
+from loguru import logger
+
 from config.convolutional_features import CONV_FEATURES, CONVOLUTION_PIPELINE
 from config.dense_features import DENSE_FEATURES, DENSE_PIPELINE
 from config.pooling_features import POOLING_FEATURES, POOLING_PIPELINE
@@ -23,6 +26,38 @@ def get_config(config_path: Path = Path("config/config.yaml")) -> Any:
     return read_yaml_file(config_path)
 
 
+def get_train_data_version(root_git_dir: str = "..") -> str | None:
+    """Get git tag corresponding to training_data.dvc file.
+
+    Args:
+        root_git_dir: Path to root of the git repo
+
+    Returns:
+        Git tag corresponding to training data
+
+    Raises:
+        Exception is thrown if tag is not found for training_data.dvc file
+    """
+    repo = Repo(root_git_dir)
+    current_commit, _ = repo.blame("HEAD", file="model_training/training_data.dvc")[0]
+    logger.debug(
+        f"Commit corresponding to 'model_training/training_data.dvc' file: {current_commit}"
+    )
+    git_cmd = repo.git
+    try:
+        current_tag = git_cmd.tag(current_commit, contains=True)
+        logger.debug(
+            f"Tag corresponding to 'model_training/training_data.dvc' file: {current_tag}"
+        )
+        return current_tag
+    except Exception as e:
+        logger.warning(
+            "No tag found for current 'model_training/training_data.dvc' file\n"
+            f"Command failed with following error : {e}"
+        )
+        return None
+
+
 def train_pipeline(
     layer_type: str,
     model_type: str,
@@ -30,6 +65,7 @@ def train_pipeline(
     features: list[str],
     pipeline_parameters: dict[str, Any],
     pattern: str,
+    data_tag: str,
 ) -> None:
     """Training pipeline.
 
@@ -41,18 +77,14 @@ def train_pipeline(
         features: List of columns to be used as features.
         pipeline_parameters: Paramters used to construct a sklearn pipeline
         pattern: Pattern used by rglob to find relevant CSV files.
+        data_tag : Name of train data tag used for training.
     """
-    data_config = config["data"]
-    model_config = config["model"]
-
     params = pipeline_parameters[model_type]
-    trainer = Trainer(
-        data_config=data_config, model_config=model_config, features=features
-    )
+    trainer = Trainer(config=config, features=features)
 
     dataset = trainer.get_dataset(pattern=pattern)
     if dataset is None:
-        print("No dataset found for training")
+        logger.warning("No dataset found for training")
         return
 
     pipeline = trainer.get_model(
@@ -68,6 +100,7 @@ def train_pipeline(
         pipeline=pipeline,
         layer_type=layer_type,
         model_type=model_type,
+        train_data_tag=data_tag,
     )
 
 
@@ -77,8 +110,12 @@ def main(config: dict) -> None:
     Args:
         config: Configuration dict.
     """
-    mlflow_config = config["mlflow"]
+    data_tag = get_train_data_version(root_git_dir="..")
+    if data_tag is None:
+        logger.critical("No data tag found for the training data")
+        exit(1)
 
+    mlflow_config = config["mlflow"]
     # Optionally enable mlflow tracking
     if mlflow_config["enable_tracking"]:
         import dagshub
@@ -91,12 +128,14 @@ def main(config: dict) -> None:
         )
 
         mlflow.set_experiment(mlflow_config["mlflow_experiment_name"])
+        logger.info(f"Found training data tag: {data_tag}")
+
         mlflow.sklearn.autolog()
 
     # Train power and runtime for convolutional layer
     for model_type in ["power", "runtime"]:
-        print("-" * 80)
-        print(f"Training for layer = convolutional and model = {model_type}")
+        logger.info("-" * 80)
+        logger.info(f"Training for layer = convolutional and model = {model_type}")
         train_pipeline(
             layer_type="convolutional",
             model_type=model_type,
@@ -104,12 +143,13 @@ def main(config: dict) -> None:
             features=CONV_FEATURES,
             pipeline_parameters=CONVOLUTION_PIPELINE,
             pattern="**/convolutional.csv",
+            data_tag=data_tag,
         )
 
     # Train power and runtime for pooling layer
     for model_type in ["power", "runtime"]:
-        print("-" * 80)
-        print(f"Training for layer = pooling and model = {model_type}")
+        logger.info("-" * 80)
+        logger.info(f"Training for layer = pooling and model = {model_type}")
         train_pipeline(
             layer_type="pooling",
             model_type=model_type,
@@ -117,12 +157,13 @@ def main(config: dict) -> None:
             features=POOLING_FEATURES,
             pipeline_parameters=POOLING_PIPELINE,
             pattern="**/pooling.csv",
+            data_tag=data_tag,
         )
 
     # Train power and runtime for pooling layer
     for model_type in ["power", "runtime"]:
-        print("-" * 80)
-        print(f"Training for layer = dense and model = {model_type}")
+        logger.info("-" * 80)
+        logger.info(f"Training for layer = dense and model = {model_type}")
         train_pipeline(
             layer_type="dense",
             model_type=model_type,
@@ -130,6 +171,7 @@ def main(config: dict) -> None:
             features=DENSE_FEATURES,
             pipeline_parameters=DENSE_PIPELINE,
             pattern="**/dense.csv",
+            data_tag=data_tag,
         )
 
 

--- a/model_training/trainer/trainer.py
+++ b/model_training/trainer/trainer.py
@@ -22,9 +22,7 @@ from model_builder.model_builder import ModelBuilder
 
 
 def get_git_branch():
-    """
-    Get current branch.
-    """
+    """Get current branch."""
     return (
         subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
         .decode("utf-8")
@@ -130,6 +128,7 @@ class Trainer:
 
         logger.info(f"Training {model_type} model")
         with mlflow.start_run(run_name=f"{layer_type}_{model_type}_model"):
+            # MLflow tags
             repo = f"git@github.com:{self.mlflow_config['dagshub_repo_owner']}/{self.mlflow_config['dagshub_repo_name']}.git"
             mlflow.set_tags(
                 {

--- a/model_training/trainer/trainer.py
+++ b/model_training/trainer/trainer.py
@@ -7,6 +7,7 @@ from typing import Any
 import matplotlib.pyplot as plt
 import mlflow
 import numpy as np
+import pandas as pd
 from loguru import logger
 from sklearn.metrics import (
     mean_absolute_error,
@@ -117,17 +118,28 @@ class Trainer:
         logger.info(f"Training samples: {len(train_dataset.input_features)}")
         logger.info(f"Testing samples: {len(test_dataset.input_features)}")
 
-        train_features = train_dataset.input_features.values
-        test_features = test_dataset.input_features.values
+        train_features = train_dataset.input_features
+        test_features = test_dataset.input_features
+
         if model_type == "power":
-            train_target = train_dataset.power.values
+            train_target = train_dataset.power
             test_target = test_dataset.power
+
         if model_type == "runtime":
-            train_target = train_dataset.runtime.values
+            train_target = train_dataset.runtime
             test_target = test_dataset.runtime
 
+        # Create mlflow dataset for logging
+        train_df = pd.concat([train_features, train_target], axis=1)
+        train_mlflow_data = mlflow.data.from_pandas(train_df, targets=model_type)
+
+        test_df = pd.concat([test_features, test_target], axis=1)
+        test_mlflow_data = mlflow.data.from_pandas(test_df, targets=model_type)
+
         logger.info(f"Training {model_type} model")
-        with mlflow.start_run(run_name=f"{layer_type}_{model_type}_model"):
+        mlflow.set_experiment(f"test_{layer_type}_{model_type}_model")
+        mlflow.sklearn.autolog(log_datasets=False)
+        with mlflow.start_run(run_name=self.mlflow_config["mlflow_experiment_name"]):
             # MLflow tags
             repo = f"git@github.com:{self.mlflow_config['dagshub_repo_owner']}/{self.mlflow_config['dagshub_repo_name']}.git"
             mlflow.set_tags(
@@ -138,8 +150,12 @@ class Trainer:
                 }
             )
 
+            # Log datasets
+            mlflow.log_input(train_mlflow_data, context="Train")
+            mlflow.log_input(test_mlflow_data, context="Eval")
+
             # Train model
-            pipeline.fit(train_features, train_target)
+            pipeline.fit(train_features.values, train_target.values)
 
             logger.info(pipeline)
             alpha = pipeline.named_steps["lasso"].alpha_
@@ -153,15 +169,17 @@ class Trainer:
                 f"n_features_in={n_features_in}"
             )
 
-            train_pred = pipeline.predict(train_features)
-            train_rmspe = Trainer.rmspe_metric(actual=train_target, pred=train_pred)
+            train_pred = pipeline.predict(train_features.values)
+            train_rmspe = Trainer.rmspe_metric(
+                actual=train_target.values, pred=train_pred
+            )
             logger.info(f"Training RMSPE: {train_rmspe}")
             mlflow.log_metrics(
                 {"training_root_mean_squared_percentage_error": train_rmspe}
             )
 
             # Evaluation
-            predictions = pipeline.predict(test_features)
+            predictions = pipeline.predict(test_features.values)
             test_metrics = Trainer.eval_metrics(actual=test_target, pred=predictions)
             logger.info(test_metrics)
             mlflow.log_metrics(test_metrics)
@@ -249,7 +267,7 @@ class Trainer:
         test_df[f"{model_type}_pred"] = pred
         test_df = test_df[["layer_name", f"{model_type}", f"{model_type}_pred"]]
         logger.info(
-            f"Predictions for {test_file_path.parent.stem} model using {model_type}\n:{test_df}"
+            f"Predictions for {test_file_path.parent.stem} model using {model_type}\n{test_df}"
         )
         # Get first 15 characters from long TensorRT layer names
         test_df.loc[:, "layer_name"] = test_df.loc[:, "layer_name"].str[:15]

--- a/model_training/trainer/trainer.py
+++ b/model_training/trainer/trainer.py
@@ -1,14 +1,13 @@
 """Trainer class."""
 
+import subprocess
 from pathlib import Path
-from pprint import pprint
 from typing import Any
 
 import matplotlib.pyplot as plt
 import mlflow
 import numpy as np
-from dataset_builder.dataset_builder import DatasetBuilder, TrainTestDataset
-from model_builder.model_builder import ModelBuilder
+from loguru import logger
 from sklearn.metrics import (
     mean_absolute_error,
     mean_absolute_percentage_error,
@@ -18,13 +17,26 @@ from sklearn.metrics import (
 )
 from sklearn.pipeline import Pipeline
 
+from dataset_builder.dataset_builder import DatasetBuilder, TrainTestDataset
+from model_builder.model_builder import ModelBuilder
+
+
+def get_git_branch():
+    """
+    Get current branch.
+    """
+    return (
+        subprocess.check_output(["git", "rev-parse", "--abbrev-ref", "HEAD"])
+        .decode("utf-8")
+        .replace("\n", "")
+    )
+
 
 class Trainer:
-    def __init__(
-        self, data_config: dict, model_config: dict, features: list[str]
-    ) -> None:
-        self.data_config = data_config
-        self.model_config = model_config
+    def __init__(self, config: dict, features: list[str]) -> None:
+        self.data_config = config["data"]
+        self.model_config = config["model"]
+        self.mlflow_config = config["mlflow"]
         self.features = features
         self.dataset_builder = DatasetBuilder(features=features)
         self.model_builder = ModelBuilder(cv=self.model_config["cross_validation"])
@@ -82,6 +94,7 @@ class Trainer:
         pipeline: Pipeline,
         layer_type: str,
         model_type: str,
+        train_data_tag: str,
     ) -> None:
         """Train and evaluation sklearn pipeline.
 
@@ -94,12 +107,17 @@ class Trainer:
             layer_type: Type of layer
             model_type: Type of model to be trained.
                 It can be either runtime or power.
+            train_data_tag : Name of train data tag used for training.
         """
         train_dataset, test_dataset = dataset.train, dataset.test
-        print(f"Number of CNN models used for training: {len(dataset.train.csv_paths)}")
-        print(f"Number of CNN models used for testing: {len(dataset.test.csv_paths)}")
-        print(f"Training samples: {len(train_dataset.input_features)}")
-        print(f"Testing samples: {len(test_dataset.input_features)}")
+        logger.info(
+            f"Number of CNN models used for training: {len(dataset.train.csv_paths)}"
+        )
+        logger.info(
+            f"Number of CNN models used for testing: {len(dataset.test.csv_paths)}"
+        )
+        logger.info(f"Training samples: {len(train_dataset.input_features)}")
+        logger.info(f"Testing samples: {len(test_dataset.input_features)}")
 
         train_features = train_dataset.input_features.values
         test_features = test_dataset.input_features.values
@@ -110,20 +128,32 @@ class Trainer:
             train_target = train_dataset.runtime.values
             test_target = test_dataset.runtime
 
-        print(f"Training {model_type} model")
+        logger.info(f"Training {model_type} model")
         with mlflow.start_run(run_name=f"{layer_type}_{model_type}_model"):
+            repo = f"git@github.com:{self.mlflow_config['dagshub_repo_owner']}/{self.mlflow_config['dagshub_repo_name']}.git"
+            mlflow.set_tags(
+                {
+                    "mlflow.source.git.branch": get_git_branch(),
+                    "mlflow.source.git.repoURL": repo,
+                    "train_data_tag": train_data_tag,
+                }
+            )
+
             # Train model
             pipeline.fit(train_features, train_target)
-            print(pipeline)
-            print(
-                pipeline.named_steps["lasso"].alpha_,
-                pipeline.named_steps["lasso"].coef_,
-                pipeline.named_steps["lasso"].intercept_,
-                pipeline.named_steps["lasso"].n_features_in_,
+
+            logger.info(pipeline)
+            alpha = pipeline.named_steps["lasso"].alpha_
+            coef = pipeline.named_steps["lasso"].coef_
+            intercept = pipeline.named_steps["lasso"].intercept_
+            n_features_in = pipeline.named_steps["lasso"].n_features_in_
+            logger.info(
+                f"Lasso model parameters: alpha={alpha}, coef={coef}, intercept={intercept}, n_features_in={n_features_in}"
             )
+
             train_pred = pipeline.predict(train_features)
             train_rmspe = Trainer.rmspe_metric(actual=train_target, pred=train_pred)
-            print(f"Training RMSPE: {train_rmspe}")
+            logger.info(f"Training RMSPE: {train_rmspe}")
             mlflow.log_metrics(
                 {"training_root_mean_squared_percentage_error": train_rmspe}
             )
@@ -131,7 +161,7 @@ class Trainer:
             # Evaluation
             predictions = pipeline.predict(test_features)
             test_metrics = Trainer.eval_metrics(actual=test_target, pred=predictions)
-            pprint(test_metrics)
+            logger.info(test_metrics)
             mlflow.log_metrics(test_metrics)
             mlflow.log_params(
                 {
@@ -216,8 +246,10 @@ class Trainer:
         pred = pipeline.predict(test_df[self.features].values)
         test_df[f"{model_type}_pred"] = pred
         test_df = test_df[["layer_name", f"{model_type}", f"{model_type}_pred"]]
-        print(f"Predictions for {test_file_path.parent.stem} model using {model_type}")
-        print(test_df)
+        logger.info(
+            f"Predictions for {test_file_path.parent.stem} model using {model_type}"
+        )
+        logger.info(test_df)
         # Get first 15 characters from long TensorRT layer names
         test_df.loc[:, "layer_name"] = test_df.loc[:, "layer_name"].str[:15]
         ax = test_df.plot(rot=90, x="layer_name", kind="bar")

--- a/model_training/trainer/trainer.py
+++ b/model_training/trainer/trainer.py
@@ -147,7 +147,10 @@ class Trainer:
             intercept = pipeline.named_steps["lasso"].intercept_
             n_features_in = pipeline.named_steps["lasso"].n_features_in_
             logger.info(
-                f"Lasso model parameters: alpha={alpha}, coef={coef}, intercept={intercept}, n_features_in={n_features_in}"
+                f"Lasso model parameters:\nalpha={alpha}\n"
+                f"coef={coef}\n"
+                f"intercept={intercept}\n"
+                f"n_features_in={n_features_in}"
             )
 
             train_pred = pipeline.predict(train_features)
@@ -246,9 +249,8 @@ class Trainer:
         test_df[f"{model_type}_pred"] = pred
         test_df = test_df[["layer_name", f"{model_type}", f"{model_type}_pred"]]
         logger.info(
-            f"Predictions for {test_file_path.parent.stem} model using {model_type}"
+            f"Predictions for {test_file_path.parent.stem} model using {model_type}\n:{test_df}"
         )
-        logger.info(test_df)
         # Get first 15 characters from long TensorRT layer names
         test_df.loc[:, "layer_name"] = test_df.loc[:, "layer_name"].str[:15]
         ax = test_df.plot(rot=90, x="layer_name", kind="bar")


### PR DESCRIPTION
In this PR, we add additional information in form of MLFlow tags to each run.

MLFlow experiment : [With tags](https://dagshub.com/fuzzylabs/edge-vision-power-estimation.mlflow/#/experiments/6?searchFilter=&orderByKey=attributes.start_time&orderByAsc=false&startTime=ALL&lifecycleFilter=Active&modelVersionFilter=All+Runs&datasetsFilter=W10%3D)

`mlflow.source.git.repoURL` does not seem to be working.