### PR TITLE
[SD-83] Update MLFlow experiments-runs structure to match model types to experiments

### DIFF
--- a/model_training/run.py
+++ b/model_training/run.py
@@ -122,17 +122,12 @@ def main(config: dict) -> None:
     # Optionally enable mlflow tracking
     if mlflow_config["enable_tracking"]:
         import dagshub
-        import mlflow
 
         dagshub.init(
             repo_name=mlflow_config["dagshub_repo_name"],
             repo_owner=mlflow_config["dagshub_repo_owner"],
             mlflow=True,
         )
-
-        mlflow.set_experiment(mlflow_config["mlflow_experiment_name"])
-
-        mlflow.sklearn.autolog()
 
     # Train power and runtime for convolutional layer
     for model_type in ["power", "runtime"]:

--- a/model_training/trainer/trainer.py
+++ b/model_training/trainer/trainer.py
@@ -7,6 +7,7 @@ from typing import Any
 import matplotlib.pyplot as plt
 import mlflow
 import numpy as np
+import pandas as pd
 from loguru import logger
 from sklearn.metrics import (
     mean_absolute_error,
@@ -117,18 +118,27 @@ class Trainer:
         logger.info(f"Training samples: {len(train_dataset.input_features)}")
         logger.info(f"Testing samples: {len(test_dataset.input_features)}")
 
-        train_features = train_dataset.input_features.values
-        test_features = test_dataset.input_features.values
+        train_features = train_dataset.input_features
+        test_features = test_dataset.input_features
+
         if model_type == "power":
-            train_target = train_dataset.power.values
+            train_target = train_dataset.power
             test_target = test_dataset.power
+
         if model_type == "runtime":
-            train_target = train_dataset.runtime.values
+            train_target = train_dataset.runtime
             test_target = test_dataset.runtime
+
+        # Create mlflow dataset for logging
+        train_df = pd.concat([train_features, train_target], axis=1)
+        train_mlflow_data = mlflow.data.from_pandas(train_df, targets=model_type)
+
+        test_df = pd.concat([test_features, test_target], axis=1)
+        test_mlflow_data = mlflow.data.from_pandas(test_df, targets=model_type)
 
         logger.info(f"Training {model_type} model")
         mlflow.set_experiment(f"test_{layer_type}_{model_type}_model")
-        mlflow.sklearn.autolog()
+        mlflow.sklearn.autolog(log_datasets=False)
         with mlflow.start_run(run_name=self.mlflow_config["mlflow_experiment_name"]):
             # MLflow tags
             repo = f"git@github.com:{self.mlflow_config['dagshub_repo_owner']}/{self.mlflow_config['dagshub_repo_name']}.git"
@@ -140,8 +150,12 @@ class Trainer:
                 }
             )
 
+            # Log datasets
+            mlflow.log_input(train_mlflow_data, context="Train")
+            mlflow.log_input(test_mlflow_data, context="Eval")
+
             # Train model
-            pipeline.fit(train_features, train_target)
+            pipeline.fit(train_features.values, train_target.values)
 
             logger.info(pipeline)
             alpha = pipeline.named_steps["lasso"].alpha_
@@ -155,15 +169,17 @@ class Trainer:
                 f"n_features_in={n_features_in}"
             )
 
-            train_pred = pipeline.predict(train_features)
-            train_rmspe = Trainer.rmspe_metric(actual=train_target, pred=train_pred)
+            train_pred = pipeline.predict(train_features.values)
+            train_rmspe = Trainer.rmspe_metric(
+                actual=train_target.values, pred=train_pred
+            )
             logger.info(f"Training RMSPE: {train_rmspe}")
             mlflow.log_metrics(
                 {"training_root_mean_squared_percentage_error": train_rmspe}
             )
 
             # Evaluation
-            predictions = pipeline.predict(test_features)
+            predictions = pipeline.predict(test_features.values)
             test_metrics = Trainer.eval_metrics(actual=test_target, pred=predictions)
             logger.info(test_metrics)
             mlflow.log_metrics(test_metrics)

--- a/model_training/trainer/trainer.py
+++ b/model_training/trainer/trainer.py
@@ -127,7 +127,9 @@ class Trainer:
             test_target = test_dataset.runtime
 
         logger.info(f"Training {model_type} model")
-        with mlflow.start_run(run_name=f"{layer_type}_{model_type}_model"):
+        mlflow.set_experiment(f"test_{layer_type}_{model_type}_model")
+        mlflow.sklearn.autolog()
+        with mlflow.start_run(run_name=self.mlflow_config["mlflow_experiment_name"]):
             # MLflow tags
             repo = f"git@github.com:{self.mlflow_config['dagshub_repo_owner']}/{self.mlflow_config['dagshub_repo_name']}.git"
             mlflow.set_tags(

--- a/model_training/trainer/trainer.py
+++ b/model_training/trainer/trainer.py
@@ -251,7 +251,7 @@ class Trainer:
         test_df[f"{model_type}_pred"] = pred
         test_df = test_df[["layer_name", f"{model_type}", f"{model_type}_pred"]]
         logger.info(
-            f"Predictions for {test_file_path.parent.stem} model using {model_type}\n:{test_df}"
+            f"Predictions for {test_file_path.parent.stem} model using {model_type}\n{test_df}"
         )
         # Get first 15 characters from long TensorRT layer names
         test_df.loc[:, "layer_name"] = test_df.loc[:, "layer_name"].str[:15]


### PR DESCRIPTION
In this PR, we change the structure of how experiments and runs are recorded in MLflow.

- Experiment -- an inidividual model we're aiming for (3x power, 3x runtime)
- Runs -- grouped by experiment/model type; names can be something meaningful that the dev inputs (like the "second-data-version-exp" we have now) or something automatic like data+commit; we can refine the naming later

MLFlow UI : [New structure](https://dagshub.com/fuzzylabs/edge-vision-power-estimation.mlflow/#/experiments/7?searchFilter=&orderByKey=attributes.start_time&orderByAsc=false&startTime=ALL&lifecycleFilter=Active&modelVersionFilter=All+Runs&datasetsFilter=W10%3D)
