### PR TITLE
[SD-125] Update `benchmark.py` to measure model layer execution latency

### DIFF
--- a/jetson/power_logging/model/benchmark.py
+++ b/jetson/power_logging/model/benchmark.py
@@ -27,7 +27,9 @@ Methods:
     - elapsed_time(): Calculates elapsed time between events
 """
 class CudaEvent:
-    time_stamp: time
+    start_time: float
+    time_stamp: float
+    event: torch.cuda.Event | None
 
     def __init__(self, enable_timing = True):
         if torch.cuda.is_available():
@@ -37,7 +39,8 @@ class CudaEvent:
             self.event = None 
 
     def record(self):
-        self.time_stamp = time.time()
+        self.start_time = time.time()
+        self.time_stamp = time.perf_counter()
         
         if self.event:
             self.event.record()
@@ -50,7 +53,7 @@ class CudaEvent:
             return n_event.time_stamp - self.time_stamp
         
     def get_time_stamp(self):
-        return self.time_stamp
+        return self.start_time
     
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"

--- a/jetson/power_logging/model/benchmark.py
+++ b/jetson/power_logging/model/benchmark.py
@@ -13,11 +13,11 @@ from typing import Any
 
 import numpy as np
 import torch
-import torch.backends.cudnn as cudnn
 from pydantic import BaseModel
 from tqdm import tqdm
 
 from model.lenet import LeNet
+from functools import partial
 
 """
 Wrapper class for Torch.cuda.event for non-CUDA supported devices
@@ -43,9 +43,6 @@ class CudaEvent:
             return self.event.elapsed_time(n_event.event)
         return 0
     
-
-
-cudnn.benchmark = True
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
 
@@ -83,8 +80,98 @@ def load_model(model_name: str, model_repo: str) -> Any:
             f"Model name: {model_name} is most likely incorrect. "
             "Please refer https://pytorch.org/hub/ to get model name."
         )
+    
+
+def get_layers(model: torch.nn.Module, name_prefix: str="") -> list[tuple[str, torch.nn.Module]]:
+    """
+    Recursively get all layers in a pytorch model.
+
+    Args:
+        model: the pytorch model to look for layers.
+        name_prefix: Use to identify the parents layer. Defaults to "".
+
+    Returns:
+        a list of tuple containing the layer name and the layer.
+    """
+    children = list(model.named_children())
+
+    if len(children) == 0: # No child
+        result = [(name_prefix, model)]
+    else:
+        # If have children, iterate over each child.
+        result = []
+        for child_name, child in children:
+            # Recursively call get_layers on the child, appending the current
+            # child's name to the name_prefix.
+            layers = get_layers(child, name_prefix + "_" + child_name)
+            result.extend(layers)
+    
+    return result
 
 
+def define_and_register_hooks(model, device) -> dict:
+    """
+        Define and register hooks with CUDA or CPU timing.
+
+    Args:
+        model: model we are registering hooks to its layers.
+        device: CPU or GPU.
+
+    Returns:
+        Dictionary containing the result.
+    """
+    layer_time_dict = {}
+
+    for layer_name, layer in get_layers(model):
+        start_event = CudaEvent() if device == "cuda" else None
+        end_event = CudaEvent() if device == "cuda" else None
+        layer.register_forward_pre_hook(partial(layer_time_pre_hook, layer_time_dict, layer_name, start_event))
+        layer.register_forward_hook(partial(layer_time_hook, layer_time_dict, layer_name, start_event, end_event))
+    
+    return layer_time_dict
+
+
+def layer_time_pre_hook(layer_time_dict, layer_name, start_event: CudaEvent, module, input) -> None:
+    """
+    Pre-hook to record start time.
+
+    Args:
+        layer_time_dict: dictionary to save hook function output.
+        layer_name: the layer to register hook.
+        start_event: an instance of the CudaEvent object use for marking the start time of before an layer execution.
+        module: the module to register hook.
+        input: tuple containing the input arguments to module's forward method.
+    """
+    if start_event:
+        start_event.record()
+        layer_time_dict[layer_name] = {"start_event": start_event}
+    else:
+        layer_time_dict[layer_name] = {"start_time": time.time()}
+
+
+def layer_time_hook(layer_time_dict, layer_name, start_event, end_event, module, input, output) -> None:
+    """
+    Hook to record end time and calculate duration.
+
+    Args:
+        layer_time_dict: dictionary to save hook function output.
+        layer_name: the layer to register hook.
+        start_event: the same instance of the CudaEvent object used in pre hook.
+        end_event: start_event: an instance of the CudaEvent object use for marking the end time of a layer execution.
+        module: the module to register hook.
+        input: tuple containing the input arguments to module's forward method.
+        output: the output tensor from the forward method.
+    """
+    if start_event:
+        end_event.record()
+        elapsed = start_event.elapsed_time(end_event)
+        layer_time_dict[layer_name]["elapsed_time"] = elapsed
+    else:
+        elapsed = time.time() - layer_time_dict[layer_name]["start_time"]
+        layer_time_dict[layer_name]["elapsed_time"] = elapsed
+
+
+# TODO: Below function needs to be updated.
 def benchmark(args: argparse.Namespace) -> None:
     """Benchmark latency and throughput across all backends.
 

--- a/jetson/power_logging/model/benchmark.py
+++ b/jetson/power_logging/model/benchmark.py
@@ -32,7 +32,7 @@ class CudaEvent:
     event: torch.cuda.Event | None
 
     def __init__(self, enable_timing = True):
-        if torch.cuda.is_available():
+        if IS_GPU:
             self.event = torch.cuda.Event(enable_timing=enable_timing)
         else:
             print("Warning: CUDA not available.")
@@ -56,7 +56,8 @@ class CudaEvent:
         return self.start_time
     
 
-DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
+IS_GPU = torch.cuda.is_available()
+DEVICE = "cuda" if IS_GPU else "cpu"
 
 
 class BenchmarkMetrics(BaseModel):
@@ -172,7 +173,7 @@ def layer_time_hook(layer_time_dict, layer_name, start_event, end_event, module,
         output: the output tensor from the forward method.
     """
     end_event.record()
-    if torch.cuda.is_available():
+    if IS_GPU:
         torch.cuda.synchronize()
     elapsed = start_event.elapsed_time(end_event)
     layer_time_dict[layer_name]["elapsed_time"] = elapsed
@@ -227,7 +228,7 @@ def benchmark(args: argparse.Namespace) -> None:
                 _ = model(input_data)
                 end_events[i].record()
 
-                if torch.cuda.is_available():
+                if IS_GPU:
                     torch.cuda.synchronize()
 
                 latency = start_events[i].elapsed_time(end_events[i])

--- a/jetson/power_logging/model/benchmark.py
+++ b/jetson/power_logging/model/benchmark.py
@@ -151,6 +151,7 @@ def layer_time_pre_hook(layer_time_dict, layer_name, start_event: CudaEvent, mod
         module: the module to register hook.
         input: tuple containing the input arguments to module's forward method.
     """
+    layer_time_dict[layer_name] = {}
     start_event.record()
 
 

--- a/jetson/power_logging/model/benchmark.py
+++ b/jetson/power_logging/model/benchmark.py
@@ -27,6 +27,8 @@ Methods:
     - elapsed_time(): Calculates elapsed time between events
 """
 class CudaEvent:
+    time_stamp: time
+
     def __init__(self, enable_timing = True):
         if torch.cuda.is_available():
             self.event = torch.cuda.Event(enable_timing=enable_timing)
@@ -35,13 +37,20 @@ class CudaEvent:
             self.event = None 
 
     def record(self):
+        self.time_stamp = time.time()
+        
         if self.event:
             self.event.record()
+
 
     def elapsed_time(self, n_event):
         if self.event and n_event.event:
             return self.event.elapsed_time(n_event.event)
-        return 0
+        else:
+            return n_event.time_stamp - self.time_stamp
+        
+    def get_time_stamp(self):
+        return self.time_stamp
     
 
 DEVICE = "cuda" if torch.cuda.is_available() else "cpu"
@@ -123,8 +132,8 @@ def define_and_register_hooks(model, device) -> dict:
     layer_time_dict = {}
 
     for layer_name, layer in get_layers(model):
-        start_event = CudaEvent() if device == "cuda" else None
-        end_event = CudaEvent() if device == "cuda" else None
+        start_event = CudaEvent(enable_timing=True)
+        end_event = CudaEvent(enable_timing=True)
         layer.register_forward_pre_hook(partial(layer_time_pre_hook, layer_time_dict, layer_name, start_event))
         layer.register_forward_hook(partial(layer_time_hook, layer_time_dict, layer_name, start_event, end_event))
     
@@ -142,11 +151,7 @@ def layer_time_pre_hook(layer_time_dict, layer_name, start_event: CudaEvent, mod
         module: the module to register hook.
         input: tuple containing the input arguments to module's forward method.
     """
-    if start_event:
-        start_event.record()
-        layer_time_dict[layer_name] = {"start_event": start_event}
-    else:
-        layer_time_dict[layer_name] = {"start_time": time.time()}
+    start_event.record()
 
 
 def layer_time_hook(layer_time_dict, layer_name, start_event, end_event, module, input, output) -> None:
@@ -162,16 +167,14 @@ def layer_time_hook(layer_time_dict, layer_name, start_event, end_event, module,
         input: tuple containing the input arguments to module's forward method.
         output: the output tensor from the forward method.
     """
-    if start_event:
-        end_event.record()
-        elapsed = start_event.elapsed_time(end_event)
-        layer_time_dict[layer_name]["elapsed_time"] = elapsed
-    else:
-        elapsed = time.time() - layer_time_dict[layer_name]["start_time"]
-        layer_time_dict[layer_name]["elapsed_time"] = elapsed
+    end_event.record()
+    if torch.cuda.is_available():
+        torch.cuda.synchronize()
+    elapsed = start_event.elapsed_time(end_event)
+    layer_time_dict[layer_name]["elapsed_time"] = elapsed
+    layer_time_dict[layer_name]["start_time"] = start_event.get_time_stamp()
 
 
-# TODO: Below function needs to be updated.
 def benchmark(args: argparse.Namespace) -> None:
     """Benchmark latency and throughput across all backends.
 
@@ -206,6 +209,9 @@ def benchmark(args: argparse.Namespace) -> None:
                 _ = model(input_data)
         print(f"Warm complete in {time.perf_counter()-st:.2f} sec ...")
 
+        layer_profiles = []
+        layer_profile = define_and_register_hooks(model, DEVICE)
+
         print("Starting timing inference ...")
         latencies = []
         start_events = [CudaEvent(enable_timing=True) for _ in range(args.runs)]
@@ -222,6 +228,7 @@ def benchmark(args: argparse.Namespace) -> None:
 
                 latency = start_events[i].elapsed_time(end_events[i])
                 latencies.append(latency * 1.0e-3)
+                layer_profiles.append(layer_profile.copy())
 
         print("Benchmarking complete ...")
 
@@ -241,10 +248,12 @@ def benchmark(args: argparse.Namespace) -> None:
 
         model_dir = f"{args.result_dir}/{args.model}"
         Path(model_dir).mkdir(exist_ok=True, parents=True)
-        file_name = f"{args.model}_tensorrt.json"
+        file_name = f"{args.model}_pytorch.json"
         file_path = f"{model_dir}/{file_name}"
         with open(file_path, "w", encoding="utf-8") as outfile:
             json.dump(results.model_dump(), outfile, indent=4)
+        with open(f"{model_dir}/{args.model}_layerwise_latency.json", "w") as layer_profiles_file:
+            json.dump(layer_profiles, layer_profiles_file)
     except Exception as e:
         print(f"An error has occurred during benchmarking: {e}")
         return


### PR DESCRIPTION
This PR updates the `benchmark.py`'s `benchmark` function to measure and save layer execution for pytorch models using layer hooks.