### PR TITLE
[SD-92] Automatically bump data version on merge

### DIFF
--- a/.github/workflows/bump_raw_data_version.yml
+++ b/.github/workflows/bump_raw_data_version.yml
@@ -4,7 +4,7 @@ on:
     types:
       - closed
     branches:
-      - master
+      - main
       - develop
     paths:
       - 'jetson/power_logging/raw_data/**.dvc'

--- a/.github/workflows/bump_raw_data_version.yml
+++ b/.github/workflows/bump_raw_data_version.yml
@@ -1,0 +1,18 @@
+name: Bump raw data version
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+      - develop
+    paths:
+      - 'jetson/power_logging/raw_data/**.dvc'
+
+jobs:
+  bump_frontend_version:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/bump_version.yml
+    with:
+      tag_namespace: "raw"

--- a/.github/workflows/bump_train_data_version.yml
+++ b/.github/workflows/bump_train_data_version.yml
@@ -1,0 +1,18 @@
+name: Bump train data version
+on:
+  pull_request:
+    types:
+      - closed
+    branches:
+      - master
+      - develop
+    paths:
+      - 'model_training/training_data.dvc'
+
+jobs:
+  bump_frontend_version:
+    permissions:
+      contents: write
+    uses: ./.github/workflows/bump_version.yml
+    with:
+      tag_namespace: "train"

--- a/.github/workflows/bump_train_data_version.yml
+++ b/.github/workflows/bump_train_data_version.yml
@@ -4,7 +4,7 @@ on:
     types:
       - closed
     branches:
-      - master
+      - main
       - develop
     paths:
       - 'model_training/training_data.dvc'

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,33 @@
+name: Bump version
+on:
+  workflow_call:
+    inputs:
+      tag_namespace:
+        required: true
+        type: string
+
+jobs:
+  bump:
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Calculate version
+        id: calculate_version
+        run: |
+          NEW_VERSION=$(git tag --sort=committerdate | grep ${{ inputs.tag_namespace }}/v | tail -1 | sed -e "s/^${{ inputs.tag_namespace }}\/v/1 + /" | bc)
+          echo "new_version=${{ inputs.tag_namespace }}/v$NEW_VERSION" >> $GITHUB_OUTPUT
+      - name: Create tag
+        uses: actions/github-script@v5
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ steps.calculate_version.outputs.new_version }}',
+              sha: context.sha
+            })


### PR DESCRIPTION
This PR adds three workflows:

* A reusable workflow to bump a version of a tag under a given namespace, e.g. backend/v3 -> backend/v4
* A workflow that is triggered on a PR merged to develop or main AND changes to raw data, to bump version of raw/vXXX
* A workflow that is triggered on a PR merged to develop or main AND changes to training data, to bump version of train/vXXX

The workflows weren't run on this repo, but I have set up an example repo with the similar workflows to demonstrate.

https://github.com/d-lowl/automatic-palm-tree/tags
https://github.com/d-lowl/automatic-palm-tree/actions/workflows/bump_frontend_version.yml
https://github.com/d-lowl/automatic-palm-tree/actions/workflows/bump_backend_version.yml

Only merge commits that had changes under particular paths
![image](https://github.com/user-attachments/assets/058feac9-2f7c-4f53-b7cf-7c43ef5064c7)
![image](https://github.com/user-attachments/assets/329fb044-5abf-4d7a-a796-af547edceeaf)
